### PR TITLE
Turne tkinter into a module like pygame and pandas

### DIFF
--- a/index.md
+++ b/index.md
@@ -106,4 +106,4 @@ General discussion about the format, duration, frequency, and topics for the mee
 - File I/O
 - `pygame`
 - `pandas`
-- TkInter
+- `tkinter`


### PR DESCRIPTION
Since Python 3, TkInter is called tkinter.